### PR TITLE
Changed refresh to update fragments rather than creating new fragment.

### DIFF
--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Activities/MainActivity.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Activities/MainActivity.java
@@ -125,6 +125,7 @@ public class MainActivity extends ScreenTrackedActivity {
                 tabLayout.setVisibility(View.VISIBLE);
                 recyclerViewSearch.setVisibility(View.GONE);
                 floorTabAdapter.getFragments().get(viewPager.getCurrentItem()).updateNeighbors();
+                //force favorites to update itself with new favorites list
                 floorTabAdapter.getFragments().get(0).favoritesUpdate();
                 return true;
             }

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Activities/MainActivity.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Activities/MainActivity.java
@@ -125,6 +125,7 @@ public class MainActivity extends ScreenTrackedActivity {
                 tabLayout.setVisibility(View.VISIBLE);
                 recyclerViewSearch.setVisibility(View.GONE);
                 floorTabAdapter.getFragments().get(viewPager.getCurrentItem()).updateNeighbors();
+                floorTabAdapter.getFragments().get(0).favoritesUpdate();
                 return true;
             }
         });

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
@@ -54,6 +54,7 @@ public class FloorTabAdapter extends FragmentPagerAdapter {
 		} else {
 			favorites = new String[] {};
 		}
+		//must instantiate list if first time through
 		if(fragments == null) {
 			fragments = new ArrayList<>();
 		}

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
@@ -28,98 +28,98 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class FloorTabAdapter extends FragmentPagerAdapter {
-	private ArrayList<String> locations;
-	private static ArrayList<FloorFragment> fragments;
-	private MainActivity context;
-	private static final String FAVORITEKEY = "favorites";
-	public static List<LocationsModel> locationsModels;
+    private ArrayList<String> locations;
+    private static ArrayList<FloorFragment> fragments;
+    private MainActivity context;
+    private static final String FAVORITEKEY = "favorites";
+    public static List<LocationsModel> locationsModels;
 
-	public FloorTabAdapter(FragmentManager fm, MainActivity context) {
-		super(fm);
-		this.context = context;
-		this.locations = new ArrayList<>();
-		this.fragments = new ArrayList<>();
-		callRetrofit(null);
-	}
+    public FloorTabAdapter(FragmentManager fm, MainActivity context) {
+        super(fm);
+        this.context = context;
+        this.locations = new ArrayList<>();
+        this.fragments = new ArrayList<>();
+        callRetrofit(null);
+    }
 
-	private void parseData(List<LocationsModel> data) {
-		//fragments.clear();
-		locations.clear();
-		locationsModels = data;
-		//notifyDataSetChanged();
-		HashMap<String, List<LocationsModel>> partitionedData = new HashMap<>();
-		String[] favorites;
-		if (Favorites.getFavorites(context) != null) {
-			favorites = Favorites.getFavorites(context).toArray(new String[0]);
-		} else {
-			favorites = new String[] {};
-		}
-		//must instantiate list if first time through
-		if(fragments == null) {
-			fragments = new ArrayList<>();
-		}
-		for (LocationsModel model : data) {
-			String floor = model.Location.Zone.ZoneName.replace("CoRec ", "");
-			if (!partitionedData.containsKey(floor)) {
-				partitionedData.put(floor, new ArrayList<LocationsModel>());
-			}
-			partitionedData.get(floor).add(model);
-			for (String s : favorites){
-				if (s.equals(model.LocationId)){
-					if (!partitionedData.containsKey(FAVORITEKEY)){
-						partitionedData.put(FAVORITEKEY, new ArrayList<LocationsModel>());
-					}
-					LocationsModel m = new LocationsModel();
-					m.Count = model.Count;
-					m.Location = model.Location;
-					m.LocationName = model.LocationName;
-					m.Capacity = model.Capacity;
-					m.LocationId = model.LocationId;
-					m.DisplayName = model.DisplayName;
-					m.EntryDate = model.EntryDate;
-					m.ZoneId = model.ZoneId;
-					partitionedData.get(FAVORITEKEY).add(m);
-				}
-			}
-		}
+    private void parseData(List<LocationsModel> data) {
+        //fragments.clear();
+        locations.clear();
+        locationsModels = data;
+        //notifyDataSetChanged();
+        HashMap<String, List<LocationsModel>> partitionedData = new HashMap<>();
+        String[] favorites;
+        if (Favorites.getFavorites(context) != null) {
+            favorites = Favorites.getFavorites(context).toArray(new String[0]);
+        } else {
+            favorites = new String[]{};
+        }
+        //must instantiate list if first time through
+        if (fragments == null) {
+            fragments = new ArrayList<>();
+        }
+        for (LocationsModel model : data) {
+            String floor = model.Location.Zone.ZoneName.replace("CoRec ", "");
+            if (!partitionedData.containsKey(floor)) {
+                partitionedData.put(floor, new ArrayList<LocationsModel>());
+            }
+            partitionedData.get(floor).add(model);
+            for (String s : favorites) {
+                if (s.equals(model.LocationId)) {
+                    if (!partitionedData.containsKey(FAVORITEKEY)) {
+                        partitionedData.put(FAVORITEKEY, new ArrayList<LocationsModel>());
+                    }
+                    LocationsModel m = new LocationsModel();
+                    m.Count = model.Count;
+                    m.Location = model.Location;
+                    m.LocationName = model.LocationName;
+                    m.Capacity = model.Capacity;
+                    m.LocationId = model.LocationId;
+                    m.DisplayName = model.DisplayName;
+                    m.EntryDate = model.EntryDate;
+                    m.ZoneId = model.ZoneId;
+                    partitionedData.get(FAVORITEKEY).add(m);
+                }
+            }
+        }
 
 
-		locations = new ArrayList<>(partitionedData.keySet());
-		boolean displayEmptyFavorites = false;
-		if (!locations.contains(FAVORITEKEY)) {
-			locations.add(FAVORITEKEY);
-			displayEmptyFavorites = true;
-		}
-		Collections.sort(locations, new Comparator<String>() {
-			@Override
-			public int compare(String s1, String s2) {
-				return getLevelRank(s1) - getLevelRank(s2);
-			}
-		});
-		if(fragments.size() == 0) {
-			//first time creating fragments
-			for (String s : locations) {
-				FloorFragment fragment = new FloorFragment();
-				if (s.equals(FAVORITEKEY)) {
-					List<LocationsModel> favModels;
-					if (displayEmptyFavorites) {
-						favModels = new ArrayList<>();
-					} else {
-						favModels = partitionedData.get(FAVORITEKEY);
-					}
-					Favorites.initalizeFavoriteFragment(favModels, context);
-					fragment.setFavFragment(true);
-					fragment.setModels(favModels, context);
-				} else {
-					fragment.setModels(partitionedData.get(s), context);
-				}
-				fragment.setMyFragmentIndex(fragments.size());
-				fragment.setLocationString(s);
-				fragments.add(fragment);
-			}
-		}else{
-			//updating fragments with the new info
-            for(FloorFragment fragment: fragments){
+        locations = new ArrayList<>(partitionedData.keySet());
+        boolean displayEmptyFavorites = false;
+        if (!locations.contains(FAVORITEKEY)) {
+            locations.add(FAVORITEKEY);
+            displayEmptyFavorites = true;
+        }
+        Collections.sort(locations, new Comparator<String>() {
+            @Override
+            public int compare(String s1, String s2) {
+                return getLevelRank(s1) - getLevelRank(s2);
+            }
+        });
+        if (fragments.size() == 0) {
+            //first time creating fragments
+            for (String s : locations) {
+                FloorFragment fragment = new FloorFragment();
+                if (s.equals(FAVORITEKEY)) {
+                    List<LocationsModel> favModels;
+                    if (displayEmptyFavorites) {
+                        favModels = new ArrayList<>();
+                    } else {
+                        favModels = partitionedData.get(FAVORITEKEY);
+                    }
+                    Favorites.initalizeFavoriteFragment(favModels, context);
+                    fragment.setFavFragment(true);
+                    fragment.setModels(favModels, context);
+                } else {
+                    fragment.setModels(partitionedData.get(s), context);
+                }
+                fragment.setMyFragmentIndex(fragments.size());
+                fragment.setLocationString(s);
+                fragments.add(fragment);
+            }
+        } else {
+            //updating fragments with the new info
+            for (FloorFragment fragment : fragments) {
                 if (fragment.getLocationString().equals(FAVORITEKEY)) {
                     List<LocationsModel> favModels;
                     if (displayEmptyFavorites) {
@@ -130,7 +130,7 @@ public class FloorTabAdapter extends FragmentPagerAdapter {
                     Favorites.initalizeFavoriteFragment(favModels, context);
                     fragment.setFavFragment(true);
                     fragment.setModels(favModels, context);
-                }else {
+                } else {
                     List<LocationsModel> model = partitionedData.get(fragment.getLocationString());
                     if (model != null) {
                         fragment.setModels(model, context);
@@ -138,109 +138,120 @@ public class FloorTabAdapter extends FragmentPagerAdapter {
                         fragment.setModels(new ArrayList<LocationsModel>(), context);
                     }
                 }
-			}
-		}
-		notifyDataSetChanged();
-		//context.swipeRefreshLayout.setRefreshing(false);
-	}
+            }
+        }
+        notifyDataSetChanged();
+        //context.swipeRefreshLayout.setRefreshing(false);
+    }
 
-	public void callRetrofit(final SwipeRefreshLayout swipeRefreshLayout) {
-		CoRecApiHelper.getInstance().getAllLocations().enqueue(new Callback<List<LocationsModel>>() {
-			@Override
-			public void onResponse(Call<List<LocationsModel>> call, Response<List<LocationsModel>> response) {
-				context.loadingBar.setVisibility(View.GONE);
-				context.status.setVisibility(View.GONE);
+    public void callRetrofit(final SwipeRefreshLayout swipeRefreshLayout) {
+        CoRecApiHelper.getInstance().getAllLocations().enqueue(new Callback<List<LocationsModel>>() {
+            @Override
+            public void onResponse(Call<List<LocationsModel>> call, Response<List<LocationsModel>> response) {
+                context.loadingBar.setVisibility(View.GONE);
+                context.status.setVisibility(View.GONE);
 
-				if (response.body() == null || response.code() != 200) {
-					Toast.makeText(context, R.string.main_loading_fail, Toast.LENGTH_LONG).show();
-					return;
-				}
-				boolean hasNonZero = false;
-				for (LocationsModel location : response.body()) {
-					if (location.Count != 0) {
-						hasNonZero = true;
-						break;
-					}
-				}
-				if (!hasNonZero) {
-					AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context)
-							.setTitle(R.string.corec_website_failure_title)
-							.setMessage(R.string.corec_website_failure)
-							.setCancelable(false)
-							.setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
-								@Override
-								public void onClick(DialogInterface dialogInterface, int i) {
-									callRetrofit(swipeRefreshLayout);
-								}
-							}).setNegativeButton(R.string.okay, new DialogInterface.OnClickListener() {
-								@Override
-								public void onClick(DialogInterface dialogInterface, int i) {
-									dialogInterface.dismiss();
-								}
-							});
-					AlertDialog failure = alertDialogBuilder.create();
-					failure.show();
-				}
-				parseData(response.body());
-				if(swipeRefreshLayout != null) {
-					swipeRefreshLayout.setRefreshing(false);
-				}
-			}
+                if (response.body() == null || response.code() != 200) {
+                    Toast.makeText(context, R.string.main_loading_fail, Toast.LENGTH_LONG).show();
+                    return;
+                }
+                boolean hasNonZero = false;
+                for (LocationsModel location : response.body()) {
+                    if (location.Count != 0) {
+                        hasNonZero = true;
+                        break;
+                    }
+                }
+                if (!hasNonZero) {
+                    AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context)
+                            .setTitle(R.string.corec_website_failure_title)
+                            .setMessage(R.string.corec_website_failure)
+                            .setCancelable(false)
+                            .setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    callRetrofit(swipeRefreshLayout);
+                                }
+                            }).setNegativeButton(R.string.okay, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    dialogInterface.dismiss();
+                                }
+                            });
+                    AlertDialog failure = alertDialogBuilder.create();
+                    failure.show();
+                }
+                parseData(response.body());
+                if (swipeRefreshLayout != null) {
+                    swipeRefreshLayout.setRefreshing(false);
+                }
+            }
 
-			@Override
-			public void onFailure(Call<List<LocationsModel>> call, Throwable t) {
-				context.loadingBar.setVisibility(View.GONE);
-				context.status.setVisibility(View.GONE);
+            @Override
+            public void onFailure(Call<List<LocationsModel>> call, Throwable t) {
+                context.loadingBar.setVisibility(View.GONE);
+                context.status.setVisibility(View.GONE);
 
-				AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context)
-						.setTitle(R.string.internet_error_title)
-						.setMessage(R.string.internet_error_message)
-						.setCancelable(false)
-						.setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
-							@Override
-							public void onClick(DialogInterface dialogInterface, int i) {
-								callRetrofit(swipeRefreshLayout);
-							}
-						});
-				AlertDialog failure = alertDialogBuilder.create();
-				failure.show();
-			}
-		});
-	}
+                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context)
+                        .setTitle(R.string.internet_error_title)
+                        .setMessage(R.string.internet_error_message)
+                        .setCancelable(false)
+                        .setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                callRetrofit(swipeRefreshLayout);
+                            }
+                        });
+                AlertDialog failure = alertDialogBuilder.create();
+                failure.show();
+            }
+        });
+    }
 
-	private int getLevelRank(String l) {
-		switch (l) {
-			case FAVORITEKEY: return -1;
-			case "Basement": return 0;
-			case "Level 1": return 1;
-			case "Level 2": return 2;
-			case "Level 3": return 3;
-			case "Level 4": return 4;
-			case "TREC": return 5;
-			case "Comp Pool": return 6;
-			case "Dive Pool": return 7;
-			case "Rec Pool": return 8;
-			default: return 9;
-		}
-	}
+    private int getLevelRank(String l) {
+        switch (l) {
+            case FAVORITEKEY:
+                return -1;
+            case "Basement":
+                return 0;
+            case "Level 1":
+                return 1;
+            case "Level 2":
+                return 2;
+            case "Level 3":
+                return 3;
+            case "Level 4":
+                return 4;
+            case "TREC":
+                return 5;
+            case "Comp Pool":
+                return 6;
+            case "Dive Pool":
+                return 7;
+            case "Rec Pool":
+                return 8;
+            default:
+                return 9;
+        }
+    }
 
-	@Nullable
-	@Override
-	public CharSequence getPageTitle(int position) {
-		return locations.get(position);
-	}
+    @Nullable
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return locations.get(position);
+    }
 
-	@Override
-	public Fragment getItem(int position) {
-		return fragments.get(position);
-	}
+    @Override
+    public Fragment getItem(int position) {
+        return fragments.get(position);
+    }
 
-	@Override
-	public int getCount() {
-		return fragments.size();
-	}
+    @Override
+    public int getCount() {
+        return fragments.size();
+    }
 
-	public static ArrayList<FloorFragment> getFragments() {
-		return fragments;
-	}
+    public static ArrayList<FloorFragment> getFragments() {
+        return fragments;
+    }
 }

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Adapters/FloorTabAdapter.java
@@ -119,7 +119,7 @@ public class FloorTabAdapter extends FragmentPagerAdapter {
 			}
 		}else{
 			//updating fragments with the new info
-			for(FloorFragment fragment: fragments){
+            for(FloorFragment fragment: fragments){
                 if (fragment.getLocationString().equals(FAVORITEKEY)) {
                     List<LocationsModel> favModels;
                     if (displayEmptyFavorites) {

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Fragments/FloorFragment.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Fragments/FloorFragment.java
@@ -38,6 +38,7 @@ public class FloorFragment extends Fragment implements SwipeRefreshLayout.OnRefr
     private CoRecAdapter coRecAdapter;
     boolean isFavFragment = false;
     int myFragmentIndex;
+    String locationString;
 
     @Nullable
     @Override
@@ -57,6 +58,7 @@ public class FloorFragment extends Fragment implements SwipeRefreshLayout.OnRefr
 
     public void updateNeighbors(){
         if(myFragmentIndex - 1 >= 0){
+            System.out.println("my fragment index for crash: " + myFragmentIndex);
             FloorTabAdapter.getFragments().get(myFragmentIndex - 1).favoritesUpdate();
         }
         FloorTabAdapter.getFragments().get(myFragmentIndex).favoritesUpdate();
@@ -100,6 +102,14 @@ public class FloorFragment extends Fragment implements SwipeRefreshLayout.OnRefr
 
     public void setMyFragmentIndex(int myFragmentIndex) {
         this.myFragmentIndex = myFragmentIndex;
+    }
+
+    public String getLocationString() {
+        return locationString;
+    }
+
+    public void setLocationString(String locationString) {
+        this.locationString = locationString;
     }
 
     @Override

--- a/app/src/main/java/club/sigapp/purduecorecmonitor/Fragments/FloorFragment.java
+++ b/app/src/main/java/club/sigapp/purduecorecmonitor/Fragments/FloorFragment.java
@@ -58,7 +58,6 @@ public class FloorFragment extends Fragment implements SwipeRefreshLayout.OnRefr
 
     public void updateNeighbors(){
         if(myFragmentIndex - 1 >= 0){
-            System.out.println("my fragment index for crash: " + myFragmentIndex);
             FloorTabAdapter.getFragments().get(myFragmentIndex - 1).favoritesUpdate();
         }
         FloorTabAdapter.getFragments().get(myFragmentIndex).favoritesUpdate();


### PR DESCRIPTION
I changed the parseData method to update fragments instead of making new ones. I had each fragment keep track of its location string and use that as reference when updating the data. The only possible issue is if there is a new location when updating the data. i.e it will not create a new tab if need be on refresh. It will notice the other way around. (no more data for tab -> empty tab)
I also fixed issue where favorites would not update if card is favorited while searching. (assumed favorites tab will always be at the 0th position in page. 

Note: can't get for loop to get right spacing at line 122 in FloorTabAdapter.java :(